### PR TITLE
fix: compilation without schemas feature

### DIFF
--- a/crates/rauth/src/lib.rs
+++ b/crates/rauth/src/lib.rs
@@ -1,8 +1,6 @@
 #[macro_use]
 extern crate serde;
 #[macro_use]
-extern crate schemars;
-#[macro_use]
 extern crate lazy_static;
 #[macro_use]
 extern crate async_trait;
@@ -13,6 +11,9 @@ extern crate log;
 #[macro_use]
 extern crate serde_json;
 
+#[cfg(feature = "schemas")]
+#[macro_use]
+extern crate schemars;
 #[cfg(feature = "database-mongodb")]
 #[macro_use]
 extern crate bson;

--- a/crates/rauth/src/result.rs
+++ b/crates/rauth/src/result.rs
@@ -1,4 +1,5 @@
-#[derive(Serialize, Debug, JsonSchema, PartialEq, Eq)]
+#[derive(Serialize, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "schemas", derive(JsonSchema))]
 #[serde(tag = "type")]
 pub enum Error {
     IncorrectData {


### PR DESCRIPTION
Fixes a bug where compiling without the schemas feature would throw compile errors related to schemars missing