### PR TITLE
feat: Allow anonymous SMTP relays

### DIFF
--- a/crates/authifier/src/config/email_verification.rs
+++ b/crates/authifier/src/config/email_verification.rs
@@ -114,7 +114,6 @@ impl SMTPSettings {
             SmtpTransport::relay(&self.host).unwrap()
         };
 
-        
         let relay = if let Some(port) = self.port {
             relay.port(port.try_into().unwrap())
         } else {
@@ -127,12 +126,16 @@ impl SMTPSettings {
             relay
         };
 
-        relay
-            .credentials(Credentials::new(
+        let relay = if !(self.username.trim().is_empty() || self.password.trim().is_empty()) {
+            relay.credentials(Credentials::new(
                 self.username.clone(),
                 self.password.clone(),
             ))
-            .build()
+        } else {
+            relay
+        };
+
+        relay.build()
     }
 
     /// Render an email template

--- a/crates/rocket_authifier/src/routes/account/create_account.rs
+++ b/crates/rocket_authifier/src/routes/account/create_account.rs
@@ -82,8 +82,6 @@ pub async fn create_account(
 mod tests {
     use crate::test::*;
     use authifier::config::{EmailVerificationConfig, SMTPSettings};
-    use chrono::Duration;
-    use iso8601_timestamp::Timestamp;
 
     #[async_std::test]
     async fn success() {

--- a/crates/rocket_authifier/src/routes/account/create_account.rs
+++ b/crates/rocket_authifier/src/routes/account/create_account.rs
@@ -81,6 +81,9 @@ pub async fn create_account(
 #[cfg(feature = "test")]
 mod tests {
     use crate::test::*;
+    use authifier::config::{EmailVerificationConfig, SMTPSettings};
+    use chrono::Duration;
+    use iso8601_timestamp::Timestamp;
 
     #[async_std::test]
     async fn success() {
@@ -394,6 +397,49 @@ mod tests {
         assert_eq!(res.status(), Status::NoContent);
 
         let mail = assert_email_sendria("create_account@smtp.test".into()).await;
+        let res = client
+            .post(format!("/verify/{}", mail.code.expect("`code`")))
+            .dispatch()
+            .await;
+
+        assert_eq!(res.status(), Status::Ok);
+    }
+
+    #[async_std::test]
+    async fn success_anonymous_smtp() {
+        let mut config = test_smtp_config().await;
+        if let EmailVerificationConfig::Enabled { smtp, .. } = &mut config.email_verification {
+            smtp.username.clear();
+            smtp.password.clear();
+        }
+
+        let (authifier, _) =
+            for_test_with_config("create_account::success_anonymous_smtp", config).await;
+        let client = bootstrap_rocket_with_auth(
+            authifier,
+            routes![
+                crate::routes::account::create_account::create_account,
+                crate::routes::account::verify_email::verify_email
+            ],
+        )
+        .await;
+
+        let res = client
+            .post("/create")
+            .header(ContentType::JSON)
+            .body(
+                json!({
+                    "email": "create_account@smtp.local",
+                    "password": "valid password",
+                })
+                .to_string(),
+            )
+            .dispatch()
+            .await;
+
+        assert_eq!(res.status(), Status::NoContent);
+
+        let mail = assert_email_sendria("create_account@smtp.local".into()).await;
         let res = client
             .post(format!("/verify/{}", mail.code.expect("`code`")))
             .dispatch()


### PR DESCRIPTION
Fixes stoatchat/stoatchat#586

Local SMTP relays may not be set up to require authentication. This PR fixes a crash where an attempt to not supply a username/password in order to avoid authentication resulted in failures with Lettre; if either the username or password is absent, the call to `.credentials` is avoided, which should leave us with the [default behaviour](https://docs.rs/lettre/latest/lettre/transport/smtp/struct.SmtpTransport.html#method.builder_dangerous) to use no authentication.

Rather than refactoring the SMTP settings to use `Option`s, I tried to keep things tightly scoped and instead this code will check if a username and password are both present before falling back to trying an anonymous connection; this should result in meaningful error messages from the relay if it were to happen by accident.